### PR TITLE
Add a deployment workflow configuration file that utilizes ssh and scp

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,68 @@
+name: Deploy to production
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "deploy"
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: 'true'
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.119.0'
+          extended: true
+
+      - name: Build
+        run: hugo -D --baseURL "https://leicesterhackspace.org.uk/"
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: SSH and prepare staging folder
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PLESK_SSH_HOST }}
+          username: ${{ secrets.PLESK_SSH_USER }}
+          key: ${{ secrets.PLESK_SSH_KEY }}
+          script: |
+            "mkdir staging"
+            "sn -l htacess staging/.htaccess"
+      - name: SCP files across
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.PLESK_SSH_HOST }}
+          username: ${{ secrets.PLESK_SSH_USER }}
+          key: ${{ secrets.PLESK_SSH_KEY }}
+          source: "public/*"
+          target: "/staging"
+      - name: SSH and make new version live
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PLESK_SSH_HOST }}
+          username: ${{ secrets.PLESK_SSH_USER }}
+          key: ${{ secrets.PLESK_SSH_KEY }}
+          script: |
+            "mv production to-be-removed"
+            "mv staging production"
+            "rm -rf to-be-removed"


### PR DESCRIPTION
A second more applicable workflow configuration for deployment (following https://github.com/leicesterhackspace/leicester-hackspace-web/pull/4).

Utilizes SSH and SCP in order to move the built website files and move them into the hosted directory