### PR TITLE
Ensure master can only be committed to from develop, add reviews to all commits and PRs

### DIFF
--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -1,7 +1,6 @@
 name: Check PR
 
 on:
-  pull_request:
   push:
   workflow_dispatch:
 

--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -2,14 +2,8 @@ name: Check PR
 
 on:
   pull_request:
-    branches:
-      - develop
   push:
-    branches:
-      - develop
   workflow_dispatch:
-    branches:
-      - develop
 
 jobs:
   build:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,13 @@
+name: pr-check.yml
+on:
+  pull_request:
+jobs:
+  dev_to_master:
+    name: Ensure master only has pull requests from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'master' && github.head_ref != 'develop'
+        run: |
+          echo "ERROR: You can only merge to main from dev."
+          exit 1


### PR DESCRIPTION
Quick cleanup of github workflows

Makes checks happen on every PR and commit

Added a new workflow to deny all PRs to master that don't come from develop