### PR TITLE
Add link to members guide/rules

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -49,6 +49,11 @@ name = 'Diary'
 pageRef = '/diary.html'
 weight = 80
 
+[[menus.right]]
+name = 'Members Guide'
+url = 'https://rules.leicesterhackspace.org.uk'
+weight = 10
+
 [privacy]
   [privacy.youtube]
     disable = false

--- a/themes/hackspace-theme/assets/sass/nav.scss
+++ b/themes/hackspace-theme/assets/sass/nav.scss
@@ -13,6 +13,12 @@ nav {
   #nav-wrap {
     display: flex;
     margin: 0;
+    width: 100%;
+
+    .spacer {
+      flex-grow: 1;
+      max-width: 100%;
+    }
 
     a {
       display: flex;
@@ -118,6 +124,10 @@ nav {
       max-height: 0;
       overflow: hidden;
       transition: 200ms ease-in;
+
+      .spacer {
+        display: none;
+      }
 
       a {
         height: 40px;

--- a/themes/hackspace-theme/layouts/partials/header.html
+++ b/themes/hackspace-theme/layouts/partials/header.html
@@ -1,1 +1,1 @@
-{{ partial "menu.html" (dict "menuID" "main" "page" .) }}
+{{ partial "menu.html" (dict "menuID" "main" "rightMenuID" "right" "page" .) }}

--- a/themes/hackspace-theme/layouts/partials/menu.html
+++ b/themes/hackspace-theme/layouts/partials/menu.html
@@ -9,23 +9,28 @@ Renders a menu for the given menu ID.
 
 {{- $page := .page }}
 {{- $menuID := .menuID }}
+{{- $rightMenuID := .rightMenuID }}
 
-{{- with index site.Menus $menuID }}
-    <nav>
-        <div id="nav-mobile">
-            {{- with resources.Get site.Params.siteImage -}}
-                {{ (. | minify).Content | safeHTML }}
-            {{- end -}}
-            <div class="nav-hamburger">
-                {{ "static/icons/fas-bars.svg" | readFile | safeHTML }}
-                {{ "static/icons/fas-xmark.svg" | readFile | safeHTML }}
-            </div>
+<nav>
+    <div id="nav-mobile">
+        {{- with resources.Get site.Params.siteImage -}}
+            {{ (. | minify).Content | safeHTML }}
+        {{- end -}}
+        <div class="nav-hamburger">
+            {{ "static/icons/fas-bars.svg" | readFile | safeHTML }}
+            {{ "static/icons/fas-xmark.svg" | readFile | safeHTML }}
         </div>
-        <div id="nav-wrap">
+    </div>
+    <div id="nav-wrap">
+        {{- with index site.Menus $menuID }}
             {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
-        </div>
-    </nav>
-{{- end }}
+        {{- end }}
+        <div class="spacer"></div>
+        {{- with index site.Menus $rightMenuID }}
+            {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
+        {{- end }}
+    </div>
+</nav>
 
 {{- define "partials/inline/menu/walk.html" }}
     {{- $page := .page }}


### PR DESCRIPTION
This required adding support for right aligned menus

Quick PR to add a button to the right side of the Nav to link to the rules

Preview: https://leicesterhackspace.github.io/leicester-hackspace-web/
<img width="1912" height="586" alt="image" src="https://github.com/user-attachments/assets/cb925f77-b620-45cb-b2bd-6947741523e5" />
