### PR TITLE
Updated deprecations, switched diary source

### DIFF
--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.149.1'
+          hugo-version: '0.161.1'
           extended: true
       - name: Build
         run: hugo

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.149.1'
+          hugo-version: '0.161.1'
           extended: true
 
       - name: Build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.149.1'
+          hugo-version: '0.161.1'
           extended: true
 
       - name: Build

--- a/content/diary.md
+++ b/content/diary.md
@@ -6,5 +6,5 @@ date = 2023-11-16T20:38:48Z
 {{< iframe src="https://calendar.google.com/calendar/embed?src=info%40leicesterhackspace.org.uk&ctz=Europe%2FLondon"
 width="100%" height="800px" attr="scrolling='no' class='desktop iframe-loading'">}}
 <!-- markdownlint-disable-next-line -->
-{{< iframe src="https://calendar.google.com/calendar/embed?mode=AGENDA?src=info%40leicesterhackspace.org.uk&ctz=Europe%2FLondon"
+{{< iframe src="https://calendar.google.com/calendar/embed?mode=AGENDA&src=info%40leicesterhackspace.org.uk&ctz=Europe%2FLondon"
 width="100%" height="500" attr="scrolling='no' class='mobile iframe-loading'">}}

--- a/content/diary.md
+++ b/content/diary.md
@@ -3,8 +3,8 @@ title = 'Diary'
 date = 2023-11-16T20:38:48Z
 +++
 <!-- markdownlint-disable-next-line -->
-{{< iframe src="https://calendar.google.com/calendar/embed?src=n116t1r43nn2t0p70u5el3002c%40group.calendar.google.com&ctz=Europe%2FLondon"
+{{< iframe src="https://calendar.google.com/calendar/embed?src=info%40leicesterhackspace.org.uk&ctz=Europe%2FLondon"
 width="100%" height="800px" attr="scrolling='no' class='desktop iframe-loading'">}}
 <!-- markdownlint-disable-next-line -->
-{{< iframe src="https://calendar.google.com/calendar/embed?mode=AGENDA&src=n116t1r43nn2t0p70u5el3002c%40group.calendar.google.com&ctz=Europe%2FLondon"
+{{< iframe src="https://calendar.google.com/calendar/embed?mode=AGENDA?src=info%40leicesterhackspace.org.uk&ctz=Europe%2FLondon"
 width="100%" height="500" attr="scrolling='no' class='mobile iframe-loading'">}}

--- a/content/news/2026-mar-create-a-con/_index.md
+++ b/content/news/2026-mar-create-a-con/_index.md
@@ -1,5 +1,5 @@
 +++
-title = '2026 Mar Create-a-Con'
+title = 'March 2026 - Create-a-Con'
 date = '2026-04-07T00:00:00Z'
 type = "posts"
 +++

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://leicesterhackspace.org.uk'
-languageCode = 'en-GB'
+locale = 'en-GB'
 title = 'Leicester Hackspace'
 theme = 'hackspace-theme'
 

--- a/themes/hackspace-theme/hugo.toml
+++ b/themes/hackspace-theme/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://https://leicesterhackspace.org.uk/'
-languageCode = 'en-gb'
+locale = 'en-GB'
 title = 'The theme for the leicester hackspace website'
 
 [params]

--- a/themes/hackspace-theme/layouts/_default/baseof.html
+++ b/themes/hackspace-theme/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html lang="{{ or site.Language.LanguageCode site.Language.Lang }}"
-      dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<html lang="{{ or site.Language.Locale site.Language.Lang }}"
+      dir="{{ or site.Language.Direction `ltr` }}">
 <head>
     {{ partial "head.html" . }}
 </head>

--- a/themes/hackspace-theme/layouts/shortcodes/groupimg.html
+++ b/themes/hackspace-theme/layouts/shortcodes/groupimg.html
@@ -8,7 +8,6 @@
 {{- $imgClass := "animate-fade" -}}
 {{- $extraClasses := or (.Get "class") "" -}}
 {{- $images := or (resources.Match (printf "%s/*.*" (.Get "images"))) (.Page.Resources.ByType "image") -}}
-{{ warnf  "%s/*.*" (.Get "images") }}
 {{- $ignore := or (.Get "ignore") slice "" -}}
 {{- $widthParam := or (.Get "width") 730 -}}
 {{- $imageHeight := or (.Get "rowHeight") "" -}}
@@ -40,7 +39,7 @@
 */}}
 {{- $alt_tag := printf "alt=%q" .Name -}}
 {{- $caption_tag := "" -}}
-{{- with .Exif -}}{{- if .Tags.ImageDescription -}}
+{{- with .Meta.Exif -}}{{- if .Tags.ImageDescription -}}
 {{- $caption_tag = (printf "<figcaption>%s</figcaption>" .Tags.ImageDescription) | safeHTML -}}{{- $alt_tag = printf "alt=%q" .Tags.ImageDescription  -}}
 {{- end -}}{{- end -}}
 


### PR DESCRIPTION
Preview available here: https://leicesterhackspace.github.io/leicester-hackspace-web/diary/

I've updated the Hugo version and fixed a few deprecations.

I lightly updated the title of the latest News post to align it to the rest of the news posts.

The main feature of this PR is to change the Diary to the new workspace, rather than the old personal google account.